### PR TITLE
Fix for Class has same name as super class

### DIFF
--- a/app/src/main/java/pt/utad/refresh/ui/ingredientes/IngredintSearchAdapter.kt
+++ b/app/src/main/java/pt/utad/refresh/ui/ingredientes/IngredintSearchAdapter.kt
@@ -14,26 +14,26 @@ import pt.utad.refresh.R
 
 class IngredientSearchAdapter(
     private val onClick: (IngredientDto) -> Unit
-) : ListAdapter<IngredientDto, IngredientSearchAdapter.ViewHolder>(DiffCallback) {
+) : ListAdapter<IngredientDto, IngredientSearchAdapter.IngredientViewHolder>(DiffCallback) {
 
     object DiffCallback : DiffUtil.ItemCallback<IngredientDto>() {
         override fun areItemsTheSame(oldItem: IngredientDto, newItem: IngredientDto) = oldItem.id == newItem.id
         override fun areContentsTheSame(oldItem: IngredientDto, newItem: IngredientDto) = oldItem == newItem
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): IngredientViewHolder {
         val view = LayoutInflater.from(parent.context)
             .inflate(R.layout.item_ingredient_search, parent, false)
-        return ViewHolder(view)
+        return IngredientViewHolder(view)
     }
 
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: IngredientViewHolder, position: Int) {
         val ingredient = getItem(position)
         holder.bind(ingredient)
         holder.itemView.setOnClickListener { onClick(ingredient) }
     }
 
-    class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    class IngredientViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val name: TextView = itemView.findViewById(R.id.ingredient_name)
         private val image: ImageView = itemView.findViewById(R.id.ingredient_image)
 


### PR DESCRIPTION
In general, to fix this type of issue you should rename the subclass so that it no longer shares the same simple name as its superclass. Using a more descriptive name also makes stack traces and references clearer.

For this file, the best minimal‑impact fix is:
- Rename the inner class `ViewHolder` to a more specific name, such as `IngredientViewHolder`.
- Update all uses of this type in the adapter: the generic parameter to `ListAdapter`, the return type of `onCreateViewHolder`, the parameter type of `onBindViewHolder`, and the constructor call `ViewHolder(view)`.

This keeps all functionality the same (same fields, same binding logic, same layout) while eliminating the confusing name clash flagged by CodeQL.

Concretely in `app/src/main/java/pt/utad/refresh/ui/ingredientes/IngredintSearchAdapter.kt`:
- Change `IngredientSearchAdapter.ViewHolder` in the `ListAdapter` superclass declaration to `IngredientSearchAdapter.IngredientViewHolder`.
- Change the class declaration `class ViewHolder(itemView: View)` to `class IngredientViewHolder(itemView: View)`.
- Update `onCreateViewHolder` to return and construct `IngredientViewHolder`.
- Update `onBindViewHolder` to take an `IngredientViewHolder` parameter.

No new methods, imports, or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._